### PR TITLE
Output path is added and relative path is deleted.

### DIFF
--- a/mftcarver/mftcarver.ps1
+++ b/mftcarver/mftcarver.ps1
@@ -1,10 +1,15 @@
+  param (
+    [string]$mftfile,
+    [string]$output="./reports"
+)
+
 clear
 
 #CHECKS IF PARSED-MFT TSV FILE IS PROVIDED
 
-if ($args.Count -lt 1) {
+if (-not $mftfile) {
 	Write-Output ""
-    Write-Output "You need to provide MFT file in TSV format as parameter!! (mftdump tool) Usage: .\mftcarver.ps1 .\lamft.tsv"
+    Write-Output "You need to provide MFT file in TSV format as parameter!! (mftdump tool) Usage: .\mftcarver.ps1 .\lamft.tsv .\output"
 	Write-Output ""
     exit
 }
@@ -12,8 +17,6 @@ if ($args.Count -lt 1) {
 #--------------------------------------------
 
 #cHECKS IF MFT FILE EXISTS
-
-$mftfile = $args[0]
 
 if (-not (Test-Path $mftfile)) {
 	Write-Output ""
@@ -26,9 +29,12 @@ if (-not (Test-Path $mftfile)) {
 
 do {
 
-if (Test-Path "./reports/*") {
+if (Test-Path $output) {
  
-	Remove-Item "./reports/*" -Force
+	Remove-Item $output/* -Force
+
+} else {
+    mkdir $output
 }
 
 		
@@ -57,7 +63,10 @@ Write-Output ""
 Write-Output "Author: George-Emilian Onofrei, 2023"
 Write-Output ""
 
-Get-ChildItem -Path ./modules/ -Filter *.ps1 | ForEach-Object { & $_.FullName $mftfile -s}
+$ScriptDirectorio = $PSScriptRoot
+$ModulesDirectorio = Join-Path $ScriptDirectorio "modules"
+
+Get-ChildItem -Path $ModulesDirectorio/ -Filter *.ps1 | ForEach-Object { & $_.FullName $mftfile -s $output}
 			
 function Press-Key {
 			Write-Output "Finished! Press any key to exit..."

--- a/mftcarver/modules/01userlogin.ps1
+++ b/mftcarver/modules/01userlogin.ps1
@@ -4,7 +4,8 @@
 		param(
 			[Parameter(Mandatory=$true)]
 			[string]$inputFile,
-			[switch]$s
+			[switch]$s,
+            [string]$d
 			 )
 			 
 	#------------------------------------------------------------
@@ -18,13 +19,13 @@
 
 	#USE REGEX VERSUS RAW MFT CSV & EXPORT TO TEMPORAL TSV
 
-		 $raw_content = Get-Content -First 1 $inputfile | Out-File ./reports/$modulename.tsv; Select-String -Pattern $regex $inputfile | Where-Object { $_.Line -notmatch '\\Users\\Default\\NTUSER\.DAT\t' } | ForEach-Object {$_.Line} | Out-File ./reports/$modulename.tsv -Append
+		 $raw_content = Get-Content -First 1 $inputfile | Out-File $d/$modulename.tsv; Select-String -Pattern $regex $inputfile | Where-Object { $_.Line -notmatch '\\Users\\Default\\NTUSER\.DAT\t' } | ForEach-Object {$_.Line} | Out-File $d/$modulename.tsv -Append
 
 	#------------------------------------------------------------
 
 	#SET SOURCE CSV
 
-		$importdata = Import-Csv -Delimiter "`t" -Path ./reports/$modulename.tsv
+		$importdata = Import-Csv -Delimiter "`t" -Path $d/$modulename.tsv
 
 	#-------------------------------------------------------------
 
@@ -38,19 +39,19 @@
 
 	#STDOUT OUTPUT
 
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "USERLOGIN MODULE RESULTS" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "USERLOGIN MODULE RESULTS" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		
 		if ($results.Count -gt 0) {
-		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*\\Users\\(.*)\\NTUSER\.DAT",'$1')} } | Sort-Object -Property "siModTime (UTC)", CleanedUsername | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_."Deleted"}}, @{Label="Username"; Expression={($_.FullPath -replace ".*\\Users\\(.*)\\NTUSER\.DAT",'$1')}}, @{Label="First Login"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="Last Login"; Expression={$_."siModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "./reports/report.txt" -Append -Width ([int]::MaxValue) ; $result
+		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*\\Users\\(.*)\\NTUSER\.DAT",'$1')} } | Sort-Object -Property "siModTime (UTC)", CleanedUsername | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_."Deleted"}}, @{Label="Username"; Expression={($_.FullPath -replace ".*\\Users\\(.*)\\NTUSER\.DAT",'$1')}}, @{Label="First Login"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="Last Login"; Expression={$_."siModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "$d/report.txt" -Append -Width ([int]::MaxValue) ; $result
 		} else {
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		}
 		
 	#------------------------------------------------------------

--- a/mftcarver/modules/02autoruns.ps1
+++ b/mftcarver/modules/02autoruns.ps1
@@ -4,7 +4,8 @@
 		param(
 			[Parameter(Mandatory=$true)]
 			[string]$inputFile,
-			[switch]$s
+			[switch]$s,
+            [string]$d
 			 )
 		 
 	#------------------------------------------------------------
@@ -18,13 +19,13 @@
 
 	#USE REGEX VERSUS RAW MFT CSV & EXPORT TO TEMPORAL TSV
 
-		 $raw_content = Get-Content -First 1 $inputfile | Out-File ./reports/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File ./reports/$modulename.tsv -Append
+		 $raw_content = Get-Content -First 1 $inputfile | Out-File $d/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File $d/$modulename.tsv -Append
 
 	#------------------------------------------------------------
 
 	#SET SOURCE CSV
 
-		$importdata = Import-Csv -Delimiter "`t" -Path ./reports/$modulename.tsv 
+		$importdata = Import-Csv -Delimiter "`t" -Path $d/$modulename.tsv 
 
 	#-------------------------------------------------------------
 
@@ -39,19 +40,19 @@
 
 	#STDOUT OUTPUT
 		
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "AUTORUNS MODULE RESULTS" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "AUTORUNS MODULE RESULTS" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		
 		if ($results.Count -gt 0) {
-		$results | Sort-Object -Property "fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="File Location"; Expression={($_.FullPath)}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "./reports/report.txt" -Append -Width ([int]::MaxValue) ; $result
+		$results | Sort-Object -Property "fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="File Location"; Expression={($_.FullPath)}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "$d/report.txt" -Append -Width ([int]::MaxValue) ; $result
 		} else {
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		}
 		
 	#------------------------------------------------------------

--- a/mftcarver/modules/03usertemp.ps1
+++ b/mftcarver/modules/03usertemp.ps1
@@ -4,7 +4,8 @@
 		param(
 			[Parameter(Mandatory=$true)]
 			[string]$inputFile,
-			[switch]$s
+			[switch]$s,
+            [string]$d
 			 )
 		 
 	#------------------------------------------------------------
@@ -18,13 +19,13 @@
 
 	#USE REGEX VERSUS RAW MFT CSV & EXPORT TO TEMPORAL TSV
 
-		 $raw_content = Get-Content -First 1 $inputfile | Out-File ./reports/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File ./reports/$modulename.tsv -Append
+		 $raw_content = Get-Content -First 1 $inputfile | Out-File $d/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File $d/$modulename.tsv -Append
 
 	#------------------------------------------------------------
 
 	#SET SOURCE CSV
 
-		$importdata = Import-Csv -Delimiter "`t" -Path ./reports/$modulename.tsv 
+		$importdata = Import-Csv -Delimiter "`t" -Path $d/$modulename.tsv 
 
 	#-------------------------------------------------------------
 
@@ -39,19 +40,19 @@
 
 	#STDOUT OUTPUT
 		
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "USERTEMP MODULE RESULTS" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "USERTEMP MODULE RESULTS" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		
 		if ($results.Count -gt 0) {
-		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2') -replace '^\?'} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2')}}, @{Label="File Location"; Expression={($_.FullPath -replace ".*\\Temp\\(.*)\\?.*$",'Temp\$1') -replace '(\?+)$',''}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "./reports/report.txt" -Append -Width ([int]::MaxValue) ; $result
+		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2') -replace '^\?'} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2')}}, @{Label="File Location"; Expression={($_.FullPath -replace ".*\\Temp\\(.*)\\?.*$",'Temp\$1') -replace '(\?+)$',''}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "$d/report.txt" -Append -Width ([int]::MaxValue) ; $result
 		} else {
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		}
 		
 	#------------------------------------------------------------

--- a/mftcarver/modules/04systemp.ps1
+++ b/mftcarver/modules/04systemp.ps1
@@ -4,7 +4,8 @@
 		param(
 			[Parameter(Mandatory=$true)]
 			[string]$inputFile,
-			[switch]$s
+			[switch]$s,
+            [string]$d
 			 )
 		 
 	#------------------------------------------------------------
@@ -18,13 +19,13 @@
 
 	#USE REGEX VERSUS RAW MFT CSV & EXPORT TO TEMPORAL TSV
 
-		 $raw_content = Get-Content -First 1 $inputfile | Out-File ./reports/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File ./reports/$modulename.tsv -Append
+		 $raw_content = Get-Content -First 1 $inputfile | Out-File $d/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File $d/$modulename.tsv -Append
 
 	#------------------------------------------------------------
 
 	#SET SOURCE CSV
 
-		$importdata = Import-Csv -Delimiter "`t" -Path ./reports/$modulename.tsv 
+		$importdata = Import-Csv -Delimiter "`t" -Path $d/$modulename.tsv 
 
 	#-------------------------------------------------------------
 
@@ -39,19 +40,19 @@
 
 	#STDOUT OUTPUT
 		
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "SYSTEMP MODULE RESULTS" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "SYSTEMP MODULE RESULTS" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		
 		if ($results.Count -gt 0) {
-		$results | Sort-Object -Property "fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="File Location"; Expression={($_.FullPath)}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "./reports/report.txt" -Append -Width ([int]::MaxValue) ; $result
+		$results | Sort-Object -Property "fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="File Location"; Expression={($_.FullPath)}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "$d/report.txt" -Append -Width ([int]::MaxValue) ; $result
 		} else {
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		}
 		
 	#------------------------------------------------------------

--- a/mftcarver/modules/05useractivity.ps1
+++ b/mftcarver/modules/05useractivity.ps1
@@ -5,7 +5,8 @@
 		param(
 			[Parameter(Mandatory=$true)]
 			[string]$inputFile,
-			[switch]$s
+			[switch]$s,
+            [string]$d
 			 )
 		 
 	#------------------------------------------------------------
@@ -19,13 +20,13 @@
 
 	#USE REGEX VERSUS RAW MFT CSV & EXPORT TO TEMPORAL TSV
 
-		 $raw_content = Get-Content -First 1 $inputfile | Out-File ./reports/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File ./reports/$modulename.tsv -Append
+		 $raw_content = Get-Content -First 1 $inputfile | Out-File $d/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File $d/$modulename.tsv -Append
 
 	#------------------------------------------------------------
 
 	#SET SOURCE CSV
 
-		$importdata = Import-Csv -Delimiter "`t" -Path ./reports/$modulename.tsv
+		$importdata = Import-Csv -Delimiter "`t" -Path $d/$modulename.tsv
 
 	#-------------------------------------------------------------
 
@@ -39,19 +40,19 @@
 
 	#STDOUT OUTPUT
 		
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "USERACTIVITY MODULE RESULTS" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "USERACTIVITY MODULE RESULTS" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		
 		if ($results.Count -gt 0) {
-		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2') -replace '^\?'} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2') -replace '^\?'} }, @{Label="File Name"; Expression={($_.FullPath -replace "\\Users\\.*\\AppData\\Roaming\\Microsoft\\(.*\.lnk)",'$1')}}, @{Label="First Access"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="Last Access"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "./reports/report.txt" -Append -Width ([int]::MaxValue) ; $result
+		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2') -replace '^\?'} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2') -replace '^\?'} }, @{Label="File Name"; Expression={($_.FullPath -replace "\\Users\\.*\\AppData\\Roaming\\Microsoft\\(.*\.lnk)",'$1')}}, @{Label="First Access"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="Last Access"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "$d/report.txt" -Append -Width ([int]::MaxValue) ; $result
 		} else {
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		}
 		
 	#------------------------------------------------------------

--- a/mftcarver/modules/06userfiles.ps1
+++ b/mftcarver/modules/06userfiles.ps1
@@ -4,7 +4,8 @@
 		param(
 			[Parameter(Mandatory=$true)]
 			[string]$inputFile,
-			[switch]$s
+			[switch]$s,
+            [string]$d
 			 )
 		 
 	#------------------------------------------------------------
@@ -18,13 +19,13 @@
 
 	#USE REGEX VERSUS RAW MFT CSV & EXPORT TO TEMPORAL TSV
 
-		 $raw_content = Get-Content -First 1 $inputfile | Out-File ./reports/$modulename.tsv; Select-String -Pattern $regex $inputfile | Where-Object { $_.Line -notmatch '.*desktop\.ini\t' } | ForEach-Object {$_.Line} | Out-File ./reports/$modulename.tsv -Append
+		 $raw_content = Get-Content -First 1 $inputfile | Out-File $d/$modulename.tsv; Select-String -Pattern $regex $inputfile | Where-Object { $_.Line -notmatch '.*desktop\.ini\t' } | ForEach-Object {$_.Line} | Out-File $d/$modulename.tsv -Append
 
 	#------------------------------------------------------------
 
 	#SET SOURCE CSV
 
-		$importdata = Import-Csv -Delimiter "`t" -Path ./reports/$modulename.tsv 
+		$importdata = Import-Csv -Delimiter "`t" -Path $d/$modulename.tsv 
 
 	#-------------------------------------------------------------
 
@@ -38,19 +39,19 @@
 
 	#STDOUT OUTPUT
 		
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "USERFILES MODULE RESULTS" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "USERFILES MODULE RESULTS" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		
 		if ($results.Count -gt 0) {
-		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace "\\Users\\(.*)\\.*\\.*",'$1')} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace "\\Users\\(.*)\\.*\\.*",'$1')}}, @{Label="File Location"; Expression={($_.FullPath -replace "\\.*\\(.*)\\(.*)$",'$1\$2')}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "./reports/report.txt" -Append -Width ([int]::MaxValue) ; $result
+		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace "\\Users\\(.*)\\.*\\.*",'$1')} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace "\\Users\\(.*)\\.*\\.*",'$1')}}, @{Label="File Location"; Expression={($_.FullPath -replace "\\.*\\(.*)\\(.*)$",'$1\$2')}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "$d/report.txt" -Append -Width ([int]::MaxValue) ; $result
 		} else {
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		}
 		
 	#------------------------------------------------------------

--- a/mftcarver/modules/07passmgr.ps1
+++ b/mftcarver/modules/07passmgr.ps1
@@ -4,7 +4,8 @@
 		param(
 			[Parameter(Mandatory=$true)]
 			[string]$inputFile,
-			[switch]$s
+			[switch]$s,
+            [string]$d
 			 )
 		 
 	#------------------------------------------------------------
@@ -18,13 +19,13 @@
 
 	#USE REGEX VERSUS RAW MFT CSV & EXPORT TO TEMPORAL TSV
 
-		 $raw_content = Get-Content -First 1 $inputfile | Out-File ./reports/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File ./reports/$modulename.tsv -Append
+		 $raw_content = Get-Content -First 1 $inputfile | Out-File $d/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File $d/$modulename.tsv -Append
 
 	#------------------------------------------------------------
 
 	#SET SOURCE CSV
 
-		$importdata = Import-Csv -Delimiter "`t" -Path ./reports/$modulename.tsv 
+		$importdata = Import-Csv -Delimiter "`t" -Path $d/$modulename.tsv 
 
 	#-------------------------------------------------------------
 
@@ -38,19 +39,19 @@
 
 	#STDOUT OUTPUT
 		
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "PASSMGR MODULE RESULTS" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "PASSMGR MODULE RESULTS" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		
 		if ($results.Count -gt 0) {
-		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2')} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2')}}, @{Label="File Location"; Expression={($_.FullPath -replace ".*\\Users\\[^\\]+\\(Desktop|Downloads|Documents|Music|Pictures|Videos)\\(.*)\\?.*$",'$1\$2') -replace '(\?+)$',''}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "./reports/report.txt" -Append -Width ([int]::MaxValue) ; $result
+		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2')} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2')}}, @{Label="File Location"; Expression={($_.FullPath -replace ".*\\Users\\[^\\]+\\(Desktop|Downloads|Documents|Music|Pictures|Videos)\\(.*)\\?.*$",'$1\$2') -replace '(\?+)$',''}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "$d/report.txt" -Append -Width ([int]::MaxValue) ; $result
 		} else {
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		}
 		
 	#------------------------------------------------------------

--- a/mftcarver/modules/08browseractivity.ps1
+++ b/mftcarver/modules/08browseractivity.ps1
@@ -4,7 +4,8 @@
 		param(
 			[Parameter(Mandatory=$true)]
 			[string]$inputFile,
-			[switch]$s
+			[switch]$s,
+            [string]$d
 			 )
 		 
 	#------------------------------------------------------------
@@ -18,13 +19,13 @@
 
 	#USE REGEX VERSUS RAW MFT CSV & EXPORT TO TEMPORAL TSV
 
-		 $raw_content = Get-Content -First 1 $inputfile | Out-File ./reports/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File ./reports/$modulename.tsv -Append
+		 $raw_content = Get-Content -First 1 $inputfile | Out-File $d/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File $d/$modulename.tsv -Append
 
 	#------------------------------------------------------------
 
 	#SET SOURCE CSV
 
-		$importdata = Import-Csv -Delimiter "`t" -Path ./reports/$modulename.tsv 
+		$importdata = Import-Csv -Delimiter "`t" -Path $d/$modulename.tsv 
 
 	#-------------------------------------------------------------
 
@@ -39,19 +40,19 @@
 
 	#STDOUT OUTPUT
 		
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "BROWSERACTIVITY MODULE RESULTS" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "BROWSERACTIVITY MODULE RESULTS" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		
 		if ($results.Count -gt 0) {
-		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2') -replace '^\?'} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2')}}, @{Label="Browser"; Expression={if($_.FullPath -match ".*Chrome.*"){"Chrome"}elseif($_.FullPath -match ".*Edge.*"){"Edge"}elseif($_.FullPath -match ".*Firefox.*"){"Firefox"}elseif($_.FullPath -match ".*Opera.*"){"Opera"}elseif($_.FullPath -match ".*\\Microsoft\\Windows.*"){"IExplorer"}else{"Unknown"}}}, @{Label="File Location"; Expression={($_.FullPath -replace '.*Users\\.*\\(Local|Roaming)\\','')}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "./reports/report.txt" -Append -Width ([int]::MaxValue) ; $result
+		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2') -replace '^\?'} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace ".*(\?\\Users\\|\\Users\\)([^\\]*)\\.*",'$2')}}, @{Label="Browser"; Expression={if($_.FullPath -match ".*Chrome.*"){"Chrome"}elseif($_.FullPath -match ".*Edge.*"){"Edge"}elseif($_.FullPath -match ".*Firefox.*"){"Firefox"}elseif($_.FullPath -match ".*Opera.*"){"Opera"}elseif($_.FullPath -match ".*\\Microsoft\\Windows.*"){"IExplorer"}else{"Unknown"}}}, @{Label="File Location"; Expression={($_.FullPath -replace '.*Users\\.*\\(Local|Roaming)\\','')}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "$d/report.txt" -Append -Width ([int]::MaxValue) ; $result
 		} else {
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		}
 		
 	#------------------------------------------------------------

--- a/mftcarver/modules/99ransom.ps1
+++ b/mftcarver/modules/99ransom.ps1
@@ -4,7 +4,8 @@
 		param(
 			[Parameter(Mandatory=$true)]
 			[string]$inputFile,
-			[switch]$s
+			[switch]$s,
+            [string]$d
 			 )
 		 
 	#------------------------------------------------------------
@@ -18,13 +19,13 @@
 
 	#USE REGEX VERSUS RAW MFT CSV & EXPORT TO TEMPORAL TSV
 
-		 $raw_content = Get-Content -First 1 $inputfile | Out-File ./reports/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File ./reports/$modulename.tsv -Append
+		 $raw_content = Get-Content -First 1 $inputfile | Out-File $d/$modulename.tsv; Select-String -Pattern $regex $inputfile | ForEach-Object {$_.Line} | Out-File $d/$modulename.tsv -Append
 
 	#------------------------------------------------------------
 
 	#SET SOURCE CSV
 
-		$importdata = Import-Csv -Delimiter "`t" -Path ./reports/$modulename.tsv 
+		$importdata = Import-Csv -Delimiter "`t" -Path $d/$modulename.tsv 
 
 	#-------------------------------------------------------------
 
@@ -38,19 +39,19 @@
 
 	#STDOUT OUTPUT
 		
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "RANSOM MODULE RESULTS" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "==========================================" | Tee-Object -FilePath "./reports/report.txt" -Append
-		Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "RANSOM MODULE RESULTS" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "==========================================" | Tee-Object -FilePath "$d/report.txt" -Append
+		Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		
 		if ($results.Count -gt 0) {
-		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace "\\Users\\(.*)\\.*\\.*",'$1')} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace "\\Users\\(.*)\\.*\\.*",'$1')}}, @{Label="File Location"; Expression={($_.FullPath -replace "\\.*\\(.*)\\(.*)$",'$1\$2')}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "./reports/report.txt" -Append -Width ([int]::MaxValue) ; $result
+		$results | Select-Object *,@{Label="CleanedUsername"; Expression={($_.FullPath -replace "\\Users\\(.*)\\.*\\.*",'$1')} } | Sort-Object -Property CleanedUsername,"fnModTime (UTC)" | Format-Table -Wrap -AutoSize -Property @{Label="MFT Entry"; Expression={$_.RecNo}}, @{Label="Deleted?"; Expression={$_.Deleted}}, @{Label="Username"; Expression={($_.FullPath -replace "\\Users\\(.*)\\.*\\.*",'$1')}}, @{Label="File Location"; Expression={($_.FullPath -replace "\\.*\\(.*)\\(.*)$",'$1\$2')}}, @{Label="fnCreateTime"; Expression={$_."fnCreateTime (UTC)"}}, @{Label="fnModTime"; Expression={$_."fnModTime (UTC)"}} | Tee-Object -Variable result | Out-File -FilePath "$d/report.txt" -Append -Width ([int]::MaxValue) ; $result
 		} else {
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
-			Write-Output "" | Tee-Object -FilePath "./reports/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "No entries found matching criteria" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
+			Write-Output "" | Tee-Object -FilePath "$d/report.txt" -Append
 		}
 		
 	#------------------------------------------------------------


### PR DESCRIPTION
Added output path, by default it uses reports, in case the folder does not exist it is created automatically. Removed relative module paths to allow execution from any system path of the mftcarver script.